### PR TITLE
Add intentionally vulnerable sample application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.6-slim
+
+ENV FLASK_APP=app/main.py
+ENV FLASK_ENV=development
+ENV SECRET_KEY="hard-coded-insecure-secret"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl openssh-client && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+
+COPY app ./app
+
+RUN pip install --no-cache-dir -r app/requirements.txt
+
+EXPOSE 5000
+
+CMD ["python", "app/main.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# securityci-check
+# Security CI Vulnerable Playground
+
+This repository intentionally contains insecure infrastructure-as-code, application code, and configuration so that you can validate static and dynamic security analysis tools.
+
+## Contents
+
+| Area | Location | Example Issues |
+| --- | --- | --- |
+| Container image | [`Dockerfile`](Dockerfile) | Outdated base image, hard-coded secrets, unnecessary packages |
+| Python web app | [`app/`](app/) | SQL injection, command injection, unsafe `exec`, debug mode |
+| Node.js service | [`node-app/`](node-app/) | `eval` usage, directory traversal, outdated dependencies |
+| Shell script | [`scripts/insecure.sh`](scripts/insecure.sh) | Unquoted variables, plaintext secrets |
+| Java sample | [`java/src/com/example/vulnerable/Vulnerable.java`](java/src/com/example/vulnerable/Vulnerable.java) | SQL injection, command execution |
+| Terraform IaC | [`terraform/main.tf`](terraform/main.tf) | Public S3 bucket, open security group, hard-coded credentials |
+| SonarQube config | [`sonar-project.properties`](sonar-project.properties) | Points scanners to vulnerable sources |
+
+## Suggested Scans
+
+Use the files in this repository to exercise the following security tools:
+
+- **Checkov, Falcon Cloud Security (IaC), Terrascan:** scan [`terraform/`](terraform/) for misconfigurations and secrets.
+- **Trivy, Grype:** scan the [`Dockerfile`](Dockerfile) or the resulting image to detect vulnerable packages and OS issues.
+- **Dependency-Track:** import [`app/requirements.txt`](app/requirements.txt) or [`node-app/package.json`](node-app/package.json) to flag outdated libraries.
+- **Semgrep:** analyze [`app/main.py`](app/main.py) and [`node-app/server.js`](node-app/server.js) for insecure patterns.
+- **ShellCheck:** lint [`scripts/insecure.sh`](scripts/insecure.sh) to find shell scripting mistakes.
+- **SonarQube:** run against the repository using [`sonar-project.properties`](sonar-project.properties) to surface code quality and security hotspots.
+
+> **Warning:** Never deploy this code to production. It is intentionally insecure and is provided only for testing and demonstration purposes.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,56 @@
+"""Intentionally vulnerable Flask application for security scanners."""
+from flask import Flask, request
+import os
+import sqlite3
+
+app = Flask(__name__)
+
+DATABASE = "users.db"
+
+
+def init_db():
+    conn = sqlite3.connect(DATABASE)
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, username TEXT, password TEXT)")
+    cursor.execute(
+        "INSERT INTO users (username, password) VALUES ('admin', 'admin')"
+    )
+    conn.commit()
+    conn.close()
+
+
+@app.route("/")
+def index():
+    return "Welcome to the vulnerable app!"
+
+
+@app.route("/search")
+def search():
+    query = request.args.get("q", "")
+    conn = sqlite3.connect(DATABASE)
+    cursor = conn.cursor()
+    sql = f"SELECT username, password FROM users WHERE username = '{query}'"
+    cursor.execute(sql)
+    result = cursor.fetchall()
+    conn.close()
+    return {"results": result, "query": query, "sql": sql}
+
+
+@app.route("/run")
+def run_command():
+    command = request.args.get("cmd", "echo no command provided")
+    return os.popen(command).read()
+
+
+@app.route("/configure", methods=["POST"])
+def configure():
+    data = request.get_json() or {}
+    secret = data.get("api_key", "")
+    os.environ["EXTERNAL_SERVICE_KEY"] = secret
+    exec(data.get("code", ""))
+    return {"status": "configured", "secret": secret}
+
+
+if __name__ == "__main__":
+    init_db()
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,3 @@
+Flask==0.12
+requests==2.19.0
+PyYAML==5.1

--- a/java/src/com/example/vulnerable/Vulnerable.java
+++ b/java/src/com/example/vulnerable/Vulnerable.java
@@ -1,0 +1,20 @@
+package com.example.vulnerable;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class Vulnerable {
+    public static void main(String[] args) throws Exception {
+        String user = args.length > 0 ? args[0] : "admin";
+        String url = "jdbc:mysql://localhost:3306/vulnerabledb?user=root&password=password";
+        Connection connection = DriverManager.getConnection(url);
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("SELECT * FROM users WHERE username = '" + user + "'");
+        while (rs.next()) {
+            System.out.println(rs.getString("username") + ":" + rs.getString("password"));
+        }
+        Runtime.getRuntime().exec("/bin/ls");
+    }
+}

--- a/node-app/package.json
+++ b/node-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "vulnerable-node-app",
+  "version": "1.0.0",
+  "description": "Sample vulnerable dependencies",
+  "dependencies": {
+    "express": "3.0.0",
+    "lodash": "4.17.10"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/node-app/server.js
+++ b/node-app/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const fs = require('fs');
+const app = express();
+
+app.get('/', (req, res) => {
+  const template = req.query.template || 'Hello ${user}!';
+  const user = req.query.user || 'guest';
+  const output = eval('`' + template + '`');
+  res.send(output);
+});
+
+app.get('/config', (req, res) => {
+  const path = req.query.path || '/etc/passwd';
+  const data = fs.readFileSync(path, 'utf8');
+  res.send(data);
+});
+
+app.listen(3000);

--- a/scripts/insecure.sh
+++ b/scripts/insecure.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+PASSWORD=plaintextpassword
+
+ls -l $1
+cat $2
+
+echo "Done"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.projectKey=vulnerable-sample
+sonar.projectName=Vulnerable Sample
+sonar.sources=app,java, scripts
+sonar.language=py

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,56 @@
+provider "aws" {
+  region                  = "us-east-1"
+  access_key              = "hardcoded-access-key"
+  secret_key              = "hardcoded-secret-key"
+  skip_credentials_validation = true
+}
+
+resource "aws_s3_bucket" "public_bucket" {
+  bucket = "insecure-public-bucket-example"
+  acl    = "public-read"
+
+  versioning {
+    enabled = false
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_security_group" "open_sg" {
+  name        = "insecure-security-group"
+  description = "Allow all inbound traffic"
+  vpc_id      = "vpc-123456"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_instance" "insecure_db" {
+  allocated_storage    = 20
+  engine               = "mysql"
+  engine_version       = "5.6"
+  instance_class       = "db.t2.micro"
+  name                 = "vulnerabledb"
+  username             = "root"
+  password             = "password"
+  skip_final_snapshot  = true
+  publicly_accessible  = true
+  storage_encrypted    = false
+}


### PR DESCRIPTION
## Summary
- add intentionally vulnerable Python and Node.js sample applications with insecure patterns for scanners
- include Terraform, Docker, and shell assets containing common misconfigurations
- document how to exercise popular security scanning tools against the repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e069fe50548329a39b0d1c71ceb8a3