### PR TITLE
Add additional vulnerable samples for security scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,27 @@ This repository intentionally contains insecure infrastructure-as-code, applicat
 | Area | Location | Example Issues |
 | --- | --- | --- |
 | Container image | [`Dockerfile`](Dockerfile) | Outdated base image, hard-coded secrets, unnecessary packages |
+| Docker Compose | [`docker-compose.yml`](docker-compose.yml) | Privileged containers, plaintext secrets, host mounts |
 | Python web app | [`app/`](app/) | SQL injection, command injection, unsafe `exec`, debug mode |
 | Node.js service | [`node-app/`](node-app/) | `eval` usage, directory traversal, outdated dependencies |
-| Shell script | [`scripts/insecure.sh`](scripts/insecure.sh) | Unquoted variables, plaintext secrets |
+| Ruby service | [`ruby-app/`](ruby-app/) | Insecure cookies, command execution, outdated gems |
+| Go service | [`go-app/`](go-app/) | SQL injection, command execution, hard-coded credentials |
+| Shell scripts | [`scripts/`](scripts/) | Unquoted variables, plaintext secrets, destructive `rm -rf` |
 | Java sample | [`java/src/com/example/vulnerable/Vulnerable.java`](java/src/com/example/vulnerable/Vulnerable.java) | SQL injection, command execution |
 | Terraform IaC | [`terraform/main.tf`](terraform/main.tf) | Public S3 bucket, open security group, hard-coded credentials |
+| Additional IaC | [`iac/`](iac/) | Insecure CloudFormation and Kubernetes manifests |
 | SonarQube config | [`sonar-project.properties`](sonar-project.properties) | Points scanners to vulnerable sources |
 
 ## Suggested Scans
 
 Use the files in this repository to exercise the following security tools:
 
-- **Checkov, Falcon Cloud Security (IaC), Terrascan:** scan [`terraform/`](terraform/) for misconfigurations and secrets.
+- **Checkov, Falcon Cloud Security (IaC), Terrascan:** scan [`terraform/`](terraform/) and [`iac/`](iac/) for misconfigurations and secrets.
 - **Trivy, Grype:** scan the [`Dockerfile`](Dockerfile) or the resulting image to detect vulnerable packages and OS issues.
-- **Dependency-Track:** import [`app/requirements.txt`](app/requirements.txt) or [`node-app/package.json`](node-app/package.json) to flag outdated libraries.
+- **Dependency-Track:** import [`app/requirements.txt`](app/requirements.txt), [`node-app/package.json`](node-app/package.json), [`ruby-app/Gemfile`](ruby-app/Gemfile), or [`go-app/go.mod`](go-app/go.mod) to flag outdated libraries.
 - **Semgrep:** analyze [`app/main.py`](app/main.py) and [`node-app/server.js`](node-app/server.js) for insecure patterns.
-- **ShellCheck:** lint [`scripts/insecure.sh`](scripts/insecure.sh) to find shell scripting mistakes.
+- **Semgrep (multilang):** extend scans to [`ruby-app/insecure.rb`](ruby-app/insecure.rb) and [`go-app/main.go`](go-app/main.go) for additional rule coverage.
+- **ShellCheck:** lint [`scripts/insecure.sh`](scripts/insecure.sh) and [`scripts/unsafe_backup.sh`](scripts/unsafe_backup.sh) to find shell scripting mistakes.
 - **SonarQube:** run against the repository using [`sonar-project.properties`](sonar-project.properties) to surface code quality and security hotspots.
 
 > **Warning:** Never deploy this code to production. It is intentionally insecure and is provided only for testing and demonstration purposes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.3'
+services:
+  vulnerable-db:
+    image: mysql:5.6
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: insecure
+    ports:
+      - "3306:3306"
+    command: ["--skip-grant-tables"]
+  vulnerable-app:
+    build: .
+    environment:
+      DATABASE_URL: mysql://root:root@vulnerable-db:3306/insecure
+      SECRET_KEY: supersecret
+    ports:
+      - "8080:80"
+    volumes:
+      - ./:/app:rw
+    privileged: true
+    depends_on:
+      - vulnerable-db

--- a/go-app/go.mod
+++ b/go-app/go.mod
@@ -1,0 +1,8 @@
+module example.com/vulnerable
+
+go 1.17
+
+require (
+    github.com/gorilla/mux v1.7.0
+    github.com/lib/pq v1.0.0
+)

--- a/go-app/main.go
+++ b/go-app/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+
+	_ "github.com/lib/pq"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Insecure Go app")
+	})
+
+	http.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
+		user := r.URL.Query().Get("user")
+		db, err := sql.Open("postgres", "postgres://admin:admin@localhost/insecure?sslmode=disable")
+		if err != nil {
+			fmt.Fprintln(w, err)
+			return
+		}
+		defer db.Close()
+		query := fmt.Sprintf("SELECT * FROM users WHERE username = '%s'", user)
+		rows, err := db.Query(query)
+		if err != nil {
+			fmt.Fprintln(w, err)
+			return
+		}
+		defer rows.Close()
+		fmt.Fprintf(w, "Executed query: %s", query)
+	})
+
+	http.HandleFunc("/exec", func(w http.ResponseWriter, r *http.Request) {
+		cmd := r.URL.Query().Get("cmd")
+		out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(w, "error: %s\n", err)
+		}
+		w.Write(out)
+	})
+
+	log.Fatal(http.ListenAndServe(":9090", nil))
+}

--- a/iac/cloudformation.yaml
+++ b/iac/cloudformation.yaml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Insecure CloudFormation template for security scanning demos
+
+Parameters:
+  DBPassword:
+    Type: String
+    Default: password123
+    NoEcho: false
+
+Resources:
+  InsecureSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow everything
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          FromPort: 0
+          ToPort: 0
+          CidrIp: 0.0.0.0/0
+
+  PublicS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: vulnerable-demo-bucket
+      AccessControl: PublicReadWrite
+      VersioningConfiguration:
+        Status: Suspended
+
+  WeakRDSInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: weak-database
+      AllocatedStorage: '5'
+      DBInstanceClass: db.t2.micro
+      Engine: mysql
+      MasterUsername: admin
+      MasterUserPassword: !Ref DBPassword
+      PubliclyAccessible: true
+      BackupRetentionPeriod: 0
+      StorageEncrypted: false
+
+Outputs:
+  BucketName:
+    Value: !Ref PublicS3Bucket
+    Description: Name of the publicly exposed bucket

--- a/iac/kubernetes.yaml
+++ b/iac/kubernetes.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insecure-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: insecure-app
+  template:
+    metadata:
+      labels:
+        app: insecure-app
+    spec:
+      hostNetwork: true
+      containers:
+        - name: insecure-app
+          image: python:3.6
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+            runAsUser: 0
+          env:
+            - name: API_TOKEN
+              value: plaintext-token
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: docker-socket
+              mountPath: /var/run/docker.sock
+      volumes:
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: insecure-app
+spec:
+  type: LoadBalancer
+  selector:
+    app: insecure-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5000

--- a/ruby-app/Gemfile
+++ b/ruby-app/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', '5.2.0'
+gem 'rack', '1.6.0'
+gem 'devise', '3.5.2'
+
+gem 'sqlite3'

--- a/ruby-app/insecure.rb
+++ b/ruby-app/insecure.rb
@@ -1,0 +1,38 @@
+# Intentionally vulnerable Ruby code
+require 'sinatra'
+require 'json'
+
+set :bind, '0.0.0.0'
+set :port, 4567
+
+def users
+  @users ||= [{ username: 'admin', password: 'admin' }]
+end
+
+get '/' do
+  'Vulnerable Ruby app'
+end
+
+get '/exec' do
+  cmd = params['cmd'] || 'ls'
+  `#{cmd}`
+end
+
+post '/login' do
+  data = JSON.parse(request.body.read)
+  username = data['username']
+  password = data['password']
+  user = users.find { |u| u[:username] == username && u[:password] == password }
+  if user
+    session_token = "token-#{rand(1000)}"
+    response.set_cookie('session', session_token, secure: false, http_only: false)
+    "Welcome #{username}!"
+  else
+    halt 401, 'Invalid credentials'
+  end
+end
+
+post '/load' do
+  file = params['file']
+  eval(File.read(file))
+end

--- a/scripts/unsafe_backup.sh
+++ b/scripts/unsafe_backup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Insecure backup script for ShellCheck demos
+BACKUP_DIR=/tmp/backups
+TARGET=$1
+AWS_SECRET=AKIAEXAMPLE123456
+
+mkdir -p $BACKUP_DIR
+cp $TARGET $BACKUP_DIR/
+chmod 777 $BACKUP_DIR/$TARGET
+rm -rf /tmp/*
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,3 @@
 sonar.projectKey=vulnerable-sample
 sonar.projectName=Vulnerable Sample
-sonar.sources=app,java, scripts
-sonar.language=py
+sonar.sources=app,java,node-app,ruby-app,go-app,scripts


### PR DESCRIPTION
## Summary
- add docker compose, Ruby, and Go application samples with intentionally vulnerable patterns
- provide insecure CloudFormation and Kubernetes manifests to expand IaC scanning coverage
- document the new examples and update SonarQube configuration to index them

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e06adb35a483298e7bed70dfdeea66